### PR TITLE
Fixed a missing import in rasterize.py

### DIFF
--- a/pyseas/maps/rasterize.py
+++ b/pyseas/maps/rasterize.py
@@ -26,6 +26,7 @@ import numpy as np
 import h3.api.numpy_int as h3
 from h3.unstable import vect
 
+from matplotlib.colors import Normalize 
 from matplotlib.image import AxesImage
 from matplotlib import rcParams
 from matplotlib import cm


### PR DESCRIPTION
Fixed a call to matplotlib.colors.Normalize without an import that was breaking raster plotting when a normalization scheme was not specified